### PR TITLE
Prefer XDG_DATA_HOME for todo data

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -76,6 +76,10 @@ impl App {
         static TODO_FILE: &str = "todo.md";
         let mut path = if let Ok(path) = std::env::var("TODUI_DIR") {
             PathBuf::from(path)
+        } else if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+            let mut xdg_data_path = PathBuf::from(data_home);
+            xdg_data_path.push("todui");
+            xdg_data_path
         } else {
             let mut home =
                 xdg_home::home_dir().ok_or(anyhow::anyhow!("Could not get home directory"))?;


### PR DESCRIPTION
App data files should reside in the user-defined XDG_DATA_HOME directory. At some point it could be desirable to split config and data as per https://specifications.freedesktop.org/basedir-spec/latest/